### PR TITLE
Fix TypeScript configuration for Netlify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 node_modules/
 dist/
+.tsbuildinfo
+*.tsbuildinfo
+vite.config.js
+vite.config.d.ts
 .env
 .env.*
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.33",
     "tailwindcss": "^3.4.1",
+    "@types/node": "^20.11.5",
     "typescript": "^5.2.2",
     "vite": "^5.0.0",
     "@vitejs/plugin-react": "^4.2.1"

--- a/src/ReformLandingJP.tsx
+++ b/src/ReformLandingJP.tsx
@@ -23,13 +23,15 @@ export default function ReformLandingJP() {
   const [submitted, setSubmitted] = useState(false);
 
   const onChange = (
-    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
-    const { name, value } = e.target;
+    const target = event.target;
 
-    if (e.target instanceof HTMLInputElement && e.target.type === "checkbox") {
-      setForm((previous) => ({ ...previous, [name]: e.target.checked }));
+    if (target instanceof HTMLInputElement && target.type === "checkbox") {
+      const { name, checked } = target;
+      setForm((previous) => ({ ...previous, [name]: checked }));
     } else {
+      const { name, value } = target;
       setForm((previous) => ({ ...previous, [name]: value }));
     }
   };

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,9 +1,13 @@
 {
   "compilerOptions": {
     "composite": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "allowSyntheticDefaultImports": true
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2020"],
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"],
+    "skipLibCheck": true
   },
   "include": ["vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- add Node type definitions and update the node tsconfig to match Vite 5 expectations
- harden the form change handler so checkbox state is typed correctly during builds
- ignore TypeScript build artifacts created by the tsc build step

## Testing
- npm run build *(fails: missing locally installed dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0bdec00008330ae82e713e286f58f