### PR TITLE
Tweak article index thumbnails layout

### DIFF
--- a/public/articles/images/bathroom-checklist.svg
+++ b/public/articles/images/bathroom-checklist.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="bathGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#cffafe" />
+      <stop offset="100%" stop-color="#a5f3fc" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" fill="url(#bathGradient)" rx="48" />
+  <g fill="none" stroke="#0f172a" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="220" y="160" width="460" height="280" rx="36" />
+    <path d="M260 360h380" />
+    <path d="M260 220h120l30 40h210" />
+    <circle cx="300" cy="320" r="22" />
+    <path d="M300 320l24 24 46-46" />
+  </g>
+</svg>

--- a/public/articles/images/construction-overview.svg
+++ b/public/articles/images/construction-overview.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="constructionGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e2e8f0" />
+      <stop offset="100%" stop-color="#cbd5f5" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#constructionGradient)" />
+  <g fill="none" stroke="#1f2937" stroke-width="12" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M200 420h500l-40-180H240z" />
+    <path d="M240 240l210-120 210 120" />
+    <path d="M360 420V300h120v120" />
+    <path d="M510 420v-90h90v90" />
+    <path d="M270 420v-90h60v90" />
+  </g>
+</svg>

--- a/public/articles/images/energy-saving.svg
+++ b/public/articles/images/energy-saving.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="energyGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#dcfce7" />
+      <stop offset="100%" stop-color="#bbf7d0" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#energyGradient)" />
+  <g fill="none" stroke="#065f46" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M450 130l90 170h-70l50 170-120-190h80z" fill="#10b981" stroke="none" opacity="0.85" />
+    <circle cx="280" cy="360" r="90" />
+    <path d="M280 270v90l60 60" />
+    <path d="M620 320c40 0 80 36 80 90 0 54-40 90-80 90-38 0-70-32-78-72" />
+  </g>
+</svg>

--- a/public/articles/images/estimate-guide.svg
+++ b/public/articles/images/estimate-guide.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="estimateGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fce7f3" />
+      <stop offset="100%" stop-color="#fbcfe8" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#estimateGradient)" />
+  <g fill="none" stroke="#831843" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="220" y="150" width="460" height="320" rx="28" />
+    <path d="M260 210h380M260 270h220m-220 60h320" />
+    <path d="M620 420l40 60 60-100" />
+    <circle cx="320" cy="420" r="32" />
+  </g>
+</svg>

--- a/public/articles/images/kitchen-storage.svg
+++ b/public/articles/images/kitchen-storage.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="kitchenGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fef3c7" />
+      <stop offset="100%" stop-color="#fde68a" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#kitchenGradient)" />
+  <g fill="none" stroke="#92400e" stroke-width="12" stroke-linejoin="round" stroke-linecap="round">
+    <rect x="180" y="150" width="540" height="300" rx="24" />
+    <path d="M180 240h540M180 330h540" />
+    <rect x="240" y="190" width="120" height="70" rx="12" />
+    <rect x="420" y="190" width="120" height="70" rx="12" />
+    <rect x="600" y="190" width="80" height="70" rx="12" />
+    <circle cx="260" cy="360" r="24" />
+    <circle cx="640" cy="360" r="24" />
+  </g>
+</svg>

--- a/public/articles/images/planning-guide.svg
+++ b/public/articles/images/planning-guide.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="900" height="600" viewBox="0 0 900 600">
+  <defs>
+    <linearGradient id="planningGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ede9fe" />
+      <stop offset="100%" stop-color="#c7d2fe" />
+    </linearGradient>
+  </defs>
+  <rect width="900" height="600" fill="url(#planningGradient)" rx="48" />
+  <g fill="none" stroke="#312e81" stroke-width="12" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="170" y="140" width="560" height="320" rx="32" />
+    <path d="M250 220h200m-200 80h120m120 0h120m-360 80h320" />
+    <circle cx="620" cy="220" r="40" />
+    <path d="M620 260v80" />
+  </g>
+</svg>

--- a/public/articles/index.html
+++ b/public/articles/index.html
@@ -60,20 +60,50 @@
         padding: 1.5rem;
         box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
       }
-      ul.article-list li a {
-        color: #111827;
+      .article-card {
+        display: grid;
+        gap: 1.25rem;
         text-decoration: none;
+        color: #111827;
       }
-      ul.article-list li a h2 {
+      .article-card-content h2 {
         margin-bottom: 0.5rem;
       }
-      ul.article-list li a:hover h2 {
+      .article-card:hover h2 {
         color: #4338ca;
+      }
+      .article-card-content {
+        display: grid;
+        gap: 0.75rem;
       }
       .article-meta {
         font-size: 0.85rem;
         color: #6b7280;
-        margin-bottom: 0.75rem;
+      }
+      .article-card-thumb {
+        border-radius: 0.75rem;
+        overflow: hidden;
+        background: #eef2ff;
+        margin: 0;
+        display: flex;
+      }
+      .article-card-thumb img {
+        display: block;
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+      }
+      @media (min-width: 768px) {
+        .article-card {
+          grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+          align-items: stretch;
+        }
+        .article-card-thumb {
+          max-width: 100%;
+        }
+        .article-card-thumb img {
+          height: 100%;
+        }
       }
       footer {
         padding: 2rem 1rem 3rem;
@@ -146,291 +176,451 @@
       <div class="layout">
         <ul class="article-list">
           <li>
-            <a href="/articles/renovation_subsidy_2025_1.html">
-              <h2>【2025年最新】リフォーム補助金を徹底解説！費用を抑えて賢く理想の住まいへ</h2>
-              <p class="article-meta">
-                <time datetime="2024-06-10">2024年6月10日公開</time>
-              </p>
-              <p>2025年に活用が期待されるリフォーム補助金について詳しく解説。国や自治体の制度、対象工事、申請の流れ、注意点まで、費用を抑えて理想の住まいを実現するための情報を網羅します。</p>
+            <a class="article-card" href="/articles/renovation_subsidy_2025_1.html">
+              <div class="article-card-content">
+                <h2>【2025年最新】リフォーム補助金を徹底解説！費用を抑えて賢く理想の住まいへ</h2>
+                <p class="article-meta">
+                  <time datetime="2024-06-10">2024年6月10日公開</time>
+                </p>
+                <p>2025年に活用が期待されるリフォーム補助金について詳しく解説。国や自治体の制度、対象工事、申請の流れ、注意点まで、費用を抑えて理想の住まいを実現するための情報を網羅します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="導入" loading="lazy" src="images_renovation_subsidy_2025_1/導入_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_uk_1.html">
-              <h2>英国の未来を左右する？リフォームUKの動向とビジネスへの影響</h2>
-              <p class="article-meta">
-                <time datetime="2024-06-01">2024年6月1日公開</time>
-              </p>
-              <p>英国政治の新たな勢力「リフォームUK」の動向を徹底解説。その政策が英国のビジネス環境に与えるメリットとリスクを深掘りします。</p>
+            <a class="article-card" href="/articles/renovation_uk_1.html">
+              <div class="article-card-content">
+                <h2>英国の未来を左右する？リフォームUKの動向とビジネスへの影響</h2>
+                <p class="article-meta">
+                  <time datetime="2024-06-01">2024年6月1日公開</time>
+                </p>
+                <p>英国政治の新たな勢力「リフォームUK」の動向を徹底解説。その政策が英国のビジネス環境に与えるメリットとリスクを深掘りします。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="英国の国会議事堂とリフォームUKのロゴ" loading="lazy" src="images_renovation_uk_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation-estimate-complete-guide.html">
-              <h2>【40代主婦向け】リフォーム見積もり完全ガイド｜費用相場・注意点・業者選び</h2>
-              <p class="article-meta">
-                <time datetime="2024-05-20">2024年5月20日公開</time>
-              </p>
-              <p>40代の主婦の方へ。リフォームの見積もりに関する費用相場、注意点、信頼できる業者の選び方まで、疑問や不安に一つひとつ丁寧にお答えする完全ガイドです。</p>
+            <a class="article-card" href="/articles/renovation-estimate-complete-guide.html">
+              <div class="article-card-content">
+                <h2>【40代主婦向け】リフォーム見積もり完全ガイド｜費用相場・注意点・業者選び</h2>
+                <p class="article-meta">
+                  <time datetime="2024-05-20">2024年5月20日公開</time>
+                </p>
+                <p>40代の主婦の方へ。リフォームの見積もりに関する費用相場、注意点、信頼できる業者の選び方まで、疑問や不安に一つひとつ丁寧にお答えする完全ガイドです。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム見積もり完全ガイドのイメージ" loading="lazy" src="images/estimate-guide.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation-planning-guide.html">
-              <h2>リフォーム計画の基本ガイド</h2>
-              <p class="article-meta">
-                <time datetime="2024-05-12">2024年5月12日公開</time>
-              </p>
-              <p>リフォーム計画を成功させるための基本を解説。目的整理から予算・スケジュールの立て方、依頼先選定まで押さえておきたいポイントをまとめました。</p>
+            <a class="article-card" href="/articles/renovation-planning-guide.html">
+              <div class="article-card-content">
+                <h2>リフォーム計画の基本ガイド</h2>
+                <p class="article-meta">
+                  <time datetime="2024-05-12">2024年5月12日公開</time>
+                </p>
+                <p>リフォーム計画を成功させるための基本を解説。目的整理から予算・スケジュールの立て方、依頼先選定まで押さえておきたいポイントをまとめました。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム計画の基本ガイドのイメージ" loading="lazy" src="images/planning-guide.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/kitchen-storage-ideas.html">
-              <h2>キッチン収納を見直す３つのポイント</h2>
-              <p class="article-meta">
-                <time datetime="2024-05-08">2024年5月8日公開</time>
-              </p>
-              <p>毎日の料理をスムーズにするために、キッチン収納を見直す３つのポイントを紹介。動線と収納量、使い勝手の改善アイデアをまとめました。</p>
+            <a class="article-card" href="/articles/kitchen-storage-ideas.html">
+              <div class="article-card-content">
+                <h2>キッチン収納を見直す３つのポイント</h2>
+                <p class="article-meta">
+                  <time datetime="2024-05-08">2024年5月8日公開</time>
+                </p>
+                <p>毎日の料理をスムーズにするために、キッチン収納を見直す３つのポイントを紹介。動線と収納量、使い勝手の改善アイデアをまとめました。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="キッチン収納のイメージ" loading="lazy" src="images/kitchen-storage.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/bathroom-renovation-checklist.html">
-              <h2>バスルーム改修チェックリスト</h2>
-              <p class="article-meta">
-                <time datetime="2024-05-05">2024年5月5日公開</time>
-              </p>
-              <p>浴室リフォームで確認したい設備や工程をチェックリスト形式でまとめた記事です。事前準備から工事後の確認まで流れを整理します。</p>
+            <a class="article-card" href="/articles/bathroom-renovation-checklist.html">
+              <div class="article-card-content">
+                <h2>バスルーム改修チェックリスト</h2>
+                <p class="article-meta">
+                  <time datetime="2024-05-05">2024年5月5日公開</time>
+                </p>
+                <p>浴室リフォームで確認したい設備や工程をチェックリスト形式でまとめた記事です。事前準備から工事後の確認まで流れを整理します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="バスルーム改修のイメージ" loading="lazy" src="images/bathroom-checklist.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/energy-saving-remodel-ideas.html">
-              <h2>省エネリフォームで光熱費を抑えるコツ</h2>
-              <p class="article-meta">
-                <time datetime="2024-05-02">2024年5月2日公開</time>
-              </p>
-              <p>断熱や高効率設備で快適性と省エネを両立させるためのリフォームアイデアをまとめました。住まいの性能向上につながる具体策をご紹介。</p>
+            <a class="article-card" href="/articles/energy-saving-remodel-ideas.html">
+              <div class="article-card-content">
+                <h2>省エネリフォームで光熱費を抑えるコツ</h2>
+                <p class="article-meta">
+                  <time datetime="2024-05-02">2024年5月2日公開</time>
+                </p>
+                <p>断熱や高効率設備で快適性と省エネを両立させるためのリフォームアイデアをまとめました。住まいの性能向上につながる具体策をご紹介。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="省エネリフォームのイメージ" loading="lazy" src="images/energy-saving.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_subsidy_1.html">
-              <h2>2024年最新！リフォーム補助金を活用し費用を抑える賢い選び方と申請ガイド</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-30">2024年4月30日公開</time>
-              </p>
-              <p>2024年の最新情報に基づき、リフォーム補助金の賢い選び方と申請方法を徹底解説。費用を抑えて理想の住まいを実現するための完全ガイドです。</p>
+            <a class="article-card" href="/articles/renovation_subsidy_1.html">
+              <div class="article-card-content">
+                <h2>2024年最新！リフォーム補助金を活用し費用を抑える賢い選び方と申請ガイド</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-30">2024年4月30日公開</time>
+                </p>
+                <p>2024年の最新情報に基づき、リフォーム補助金の賢い選び方と申請方法を徹底解説。費用を抑えて理想の住まいを実現するための完全ガイドです。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="2024年最新！リフォーム補助金を活用し費用を抑える賢い選び方と申請ガイド" loading="lazy" src="images_renovation_subsidy_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/kitchen_renovation_1.html">
-              <h2>後悔しないキッチンリフォーム！費用相場と成功のポイントを徹底解説</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-29">2024年4月29日公開</time>
-              </p>
-              <p>キッチンリフォームを検討中のあなたへ。後悔しない理想のキッチンを実現するための費用相場、成功のポイント、キッチンの選び方、リフォーム会社の選び方まで徹底解説します。</p>
+            <a class="article-card" href="/articles/kitchen_renovation_1.html">
+              <div class="article-card-content">
+                <h2>後悔しないキッチンリフォーム！費用相場と成功のポイントを徹底解説</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-29">2024年4月29日公開</time>
+                </p>
+                <p>キッチンリフォームを検討中のあなたへ。後悔しない理想のキッチンを実現するための費用相場、成功のポイント、キッチンの選び方、リフォーム会社の選び方まで徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="後悔しないキッチンリフォームのイメージ" loading="lazy" src="images_kitchen_renovation_1/タイトル（H1）_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/reform_osaka_1.html">
-              <h2>大阪で理想のキッチンリフォーム！失敗しない業者選びと費用ガイド</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-28">2024年4月28日公開</time>
-              </p>
-              <p>大阪でキッチンリフォームを成功させるための完全ガイド。信頼できる業者の選び方から費用相場、補助金情報まで詳しく解説します。</p>
+            <a class="article-card" href="/articles/reform_osaka_1.html">
+              <div class="article-card-content">
+                <h2>大阪で理想のキッチンリフォーム！失敗しない業者選びと費用ガイド</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-28">2024年4月28日公開</time>
+                </p>
+                <p>大阪でキッチンリフォームを成功させるための完全ガイド。信頼できる業者の選び方から費用相場、補助金情報まで詳しく解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="大阪で理想のキッチンリフォーム！失敗しない業者選びと費用ガイド" loading="lazy" src="images_reform_osaka_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/reform_toilet_1.html">
-              <h2>【リフォームトイレ】快適で家計に優しい！失敗しない選び方と費用ガイド</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-27">2024年4月27日公開</time>
-              </p>
-              <p>トイレリフォームで失敗しないための完全ガイド。最新トイレの機能、メリット・デメリット、費用相場、信頼できる業者の選び方まで詳しく解説します。</p>
+            <a class="article-card" href="/articles/reform_toilet_1.html">
+              <div class="article-card-content">
+                <h2>【リフォームトイレ】快適で家計に優しい！失敗しない選び方と費用ガイド</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-27">2024年4月27日公開</time>
+                </p>
+                <p>トイレリフォームで失敗しないための完全ガイド。最新トイレの機能、メリット・デメリット、費用相場、信頼できる業者の選び方まで詳しく解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="【リフォームトイレ】快適で家計に優しい！失敗しない選び方と費用ガイド" loading="lazy" src="images_reform_toilet_1/タイトル（H1）_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/reform_tatami_1.html">
-              <h2>畳リフォームで快適な和室へ！安全・掃除楽々を実現する選び方</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-26">2024年4月26日公開</time>
-              </p>
-              <p>畳リフォームの種類や費用、業者の選び方を徹底解説。安全で掃除がしやすく、快適な和室を実現するためのポイントを紹介します。</p>
+            <a class="article-card" href="/articles/reform_tatami_1.html">
+              <div class="article-card-content">
+                <h2>畳リフォームで快適な和室へ！安全・掃除楽々を実現する選び方</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-26">2024年4月26日公開</time>
+                </p>
+                <p>畳リフォームの種類や費用、業者の選び方を徹底解説。安全で掃除がしやすく、快適な和室を実現するためのポイントを紹介します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="畳のある快適な和室" loading="lazy" src="images_reform_tatami_1/導入_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/reform_sanko_service_1.html">
-              <h2>リフォーム三光サービスで洋服お直し！忙しいあなたも安心の理由</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-25">2024年4月25日公開</time>
-              </p>
-              <p>お気に入りの洋服を蘇らせる「リフォーム三光サービス」。忙しいあなたでも安心して利用できる理由を、豊富なサービス内容や熟練の技術、便利な利用方法から徹底解説します。</p>
+            <a class="article-card" href="/articles/reform_sanko_service_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム三光サービスで洋服お直し！忙しいあなたも安心の理由</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-25">2024年4月25日公開</time>
+                </p>
+                <p>お気に入りの洋服を蘇らせる「リフォーム三光サービス」。忙しいあなたでも安心して利用できる理由を、豊富なサービス内容や熟練の技術、便利な利用方法から徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム三光サービスで洋服お直し！忙しいあなたも安心の理由" loading="lazy" src="images_reform_sanko_service_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_price_1.html">
-              <h2>リフォームの値段はいくら？費用相場と後悔しないための全知識</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-24">2024年4月24日公開</time>
-              </p>
-              <p>リフォームの費用相場や後悔しないための知識を網羅的に解説。キッチン、お風呂、トイレなど場所別の値段から、費用を抑えるコツまで紹介します。</p>
+            <a class="article-card" href="/articles/remodel_price_1.html">
+              <div class="article-card-content">
+                <h2>リフォームの値段はいくら？費用相場と後悔しないための全知識</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-24">2024年4月24日公開</time>
+                </p>
+                <p>リフォームの費用相場や後悔しないための知識を網羅的に解説。キッチン、お風呂、トイレなど場所別の値段から、費用を抑えるコツまで紹介します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームの値段はいくら？費用相場と後悔しないための全知識" loading="lazy" src="images_remodel_price_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_company_1.html">
-              <h2>【40代向け】後悔しないリフォーム会社の選び方と費用相場</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-23">2024年4月23日公開</time>
-              </p>
-              <p>40代からのリフォームを成功させるための会社選びのポイント、費用相場、注意点を徹底解説。信頼できるパートナーを見つけて、理想の住まいを実現しましょう。</p>
+            <a class="article-card" href="/articles/remodel_company_1.html">
+              <div class="article-card-content">
+                <h2>【40代向け】後悔しないリフォーム会社の選び方と費用相場</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-23">2024年4月23日公開</time>
+                </p>
+                <p>40代からのリフォームを成功させるための会社選びのポイント、費用相場、注意点を徹底解説。信頼できるパートナーを見つけて、理想の住まいを実現しましょう。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームを検討する40代夫婦のイメージ" loading="lazy" src="images_remodel_company_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_mama_1.html">
-              <h2>子育てママのリフォーム成功術！快適で安全な家づくり</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-22">2024年4月22日公開</time>
-              </p>
-              <p>子育て世代の悩みを解決し、家族みんながもっと笑顔で快適に暮らすためのリフォーム成功術を、実例や費用、業者の選び方まで詳しく解説します。</p>
+            <a class="article-card" href="/articles/remodel_mama_1.html">
+              <div class="article-card-content">
+                <h2>子育てママのリフォーム成功術！快適で安全な家づくり</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-22">2024年4月22日公開</time>
+                </p>
+                <p>子育て世代の悩みを解決し、家族みんながもっと笑顔で快適に暮らすためのリフォーム成功術を、実例や費用、業者の選び方まで詳しく解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="子育てママのリフォーム成功術！快適で安全な家づくり" loading="lazy" src="images_remodel_mama_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodeler_1.html">
-              <h2>リフォーム業者選びで失敗しない！後悔しないための全知識</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-21">2024年4月21日公開</time>
-              </p>
-              <p>リフォームで後悔しないための業者選びの全知識を解説。基礎知識から信頼できる業者の見極め方、悪徳業者から身を守る注意点まで網羅します。</p>
+            <a class="article-card" href="/articles/remodeler_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム業者選びで失敗しない！後悔しないための全知識</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-21">2024年4月21日公開</time>
+                </p>
+                <p>リフォームで後悔しないための業者選びの全知識を解説。基礎知識から信頼できる業者の見極め方、悪徳業者から身を守る注意点まで網羅します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム業者選びで失敗しないための基礎知識" loading="lazy" src="images_remodeler_1/段落1（H2）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_estimate_1.html">
-              <h2>【50代女性向け】リフォーム見積もりで失敗しない！賢い依頼と確認のコツ</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-20">2024年4月20日公開</time>
-              </p>
-              <p>50代女性がリフォーム見積もりで失敗しないための賢い依頼方法と確認のコツを徹底解説。基本からチェックポイントまで、安心して理想のリフォームを実現するための知識をご紹介します。</p>
+            <a class="article-card" href="/articles/renovation_estimate_1.html">
+              <div class="article-card-content">
+                <h2>【50代女性向け】リフォーム見積もりで失敗しない！賢い依頼と確認のコツ</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-20">2024年4月20日公開</time>
+                </p>
+                <p>50代女性がリフォーム見積もりで失敗しないための賢い依頼方法と確認のコツを徹底解説。基本からチェックポイントまで、安心して理想のリフォームを実現するための知識をご紹介します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="【50代女性向け】リフォーム見積もりで失敗しない！賢い依頼と確認のコツ" loading="lazy" src="images_renovation_estimate_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_estimate_app_1.html">
-              <h2>リフォームの見積もりアプリで費用を把握！失敗しない選び方と活用術</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-19">2024年4月19日公開</time>
-              </p>
-              <p>リフォームを考え始めた方の「費用はいくら？」という不安を解消する「リフォーム見積もりアプリ」。そのメリット・デメリットから、失敗しない選び方、計画を成功に導く活用術までを徹底解説します。</p>
+            <a class="article-card" href="/articles/renovation_estimate_app_1.html">
+              <div class="article-card-content">
+                <h2>リフォームの見積もりアプリで費用を把握！失敗しない選び方と活用術</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-19">2024年4月19日公開</time>
+                </p>
+                <p>リフォームを考え始めた方の「費用はいくら？」という不安を解消する「リフォーム見積もりアプリ」。そのメリット・デメリットから、失敗しない選び方、計画を成功に導く活用術までを徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームの見積もりアプリで費用を把握！失敗しない選び方と活用術" loading="lazy" src="images_renovation_estimate_app_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_estimate_discount_negotiation_1.html">
-              <h2>リフォーム見積もりの値引き交渉術！失敗しないコツと費用を抑える方法</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-18">2024年4月18日公開</time>
-              </p>
-              <p>リフォームの見積もりで損しないための値引き交渉術を徹底解説。失敗しないコツや費用を抑える具体的な方法、交渉の相場からメリット・デメリットまで網羅します。</p>
+            <a class="article-card" href="/articles/renovation_estimate_discount_negotiation_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム見積もりの値引き交渉術！失敗しないコツと費用を抑える方法</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-18">2024年4月18日公開</time>
+                </p>
+                <p>リフォームの見積もりで損しないための値引き交渉術を徹底解説。失敗しないコツや費用を抑える具体的な方法、交渉の相場からメリット・デメリットまで網羅します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム見積もりの値引き交渉術！失敗しないコツと費用を抑える方法" loading="lazy" src="images_renovation_estimate_discount_negotiation_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_construction_1.html">
-              <h2>リフォーム工事の全体像を把握！費用・種類・業者選びのポイントを徹底解説</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-17">2024年4月17日公開</time>
-              </p>
-              <p>リフォームを成功させるための全体像を徹底解説。目的の明確化から費用相場、種類、失敗しない業者選びのポイントまで、初心者にも分かりやすくガイドします。</p>
+            <a class="article-card" href="/articles/renovation_construction_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム工事の全体像を把握！費用・種類・業者選びのポイントを徹底解説</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-17">2024年4月17日公開</time>
+                </p>
+                <p>リフォームを成功させるための全体像を徹底解説。目的の明確化から費用相場、種類、失敗しない業者選びのポイントまで、初心者にも分かりやすくガイドします。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム工事の全体像をイメージした図" loading="lazy" src="images/construction-overview.svg" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_condo_1.html">
-              <h2>マンションリフォームで理想の住まいを！費用相場から注意点まで徹底解説</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-16">2024年4月16日公開</time>
-              </p>
-              <p>マンションリフォームの費用相場、できること、メリット・デメリット、業者選びのコツまで、理想の住まいを実現するための情報を徹底解説します。</p>
+            <a class="article-card" href="/articles/renovation_condo_1.html">
+              <div class="article-card-content">
+                <h2>マンションリフォームで理想の住まいを！費用相場から注意点まで徹底解説</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-16">2024年4月16日公開</time>
+                </p>
+                <p>マンションリフォームの費用相場、できること、メリット・デメリット、業者選びのコツまで、理想の住まいを実現するための情報を徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="マンションリフォームで理想の住まいを！費用相場から注意点まで徹底解説" loading="lazy" src="images_renovation_condo_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_door_frame_1.html">
-              <h2>リフォーム框で玄関DIY！選び方から取り付け手順まで徹底解説</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-15">2024年4月15日公開</time>
-              </p>
-              <p>リフォーム框を使った玄関DIYの完全ガイド。初心者でも安心の選び方、具体的な取り付け手順、メリット・デメリットまで、成功に必要な情報を徹底解説します。</p>
+            <a class="article-card" href="/articles/renovation_door_frame_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム框で玄関DIY！選び方から取り付け手順まで徹底解説</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-15">2024年4月15日公開</time>
+                </p>
+                <p>リフォーム框を使った玄関DIYの完全ガイド。初心者でも安心の選び方、具体的な取り付け手順、メリット・デメリットまで、成功に必要な情報を徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム框で玄関DIY！選び方から取り付け手順まで徹底解説" loading="lazy" src="images_renovation_door_frame_1/タイトル（H1）_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_outlet_1.html">
-              <h2>リフォームアウトレットで賢く費用を抑える！失敗しない選び方と注意点</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-14">2024年4月14日公開</time>
-              </p>
-              <p>高品質な住宅設備や建材を驚くほど手頃な価格で手に入れる「リフォームアウトレット」の活用法を徹底解説。失敗しない選び方からメリット・デメリット、注意点まで、賢いリフォーム計画の全てがわかります。</p>
+            <a class="article-card" href="/articles/renovation_outlet_1.html">
+              <div class="article-card-content">
+                <h2>リフォームアウトレットで賢く費用を抑える！失敗しない選び方と注意点</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-14">2024年4月14日公開</time>
+                </p>
+                <p>高品質な住宅設備や建材を驚くほど手頃な価格で手に入れる「リフォームアウトレット」の活用法を徹底解説。失敗しない選び方からメリット・デメリット、注意点まで、賢いリフォーム計画の全てがわかります。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームアウトレットで賢く費用を抑える！失敗しない選び方と注意点" loading="lazy" src="images_renovation_outlet_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_sales_1.html">
-              <h2>リフォーム営業で成果を出す！新築経験を活かす提案術と成功の秘訣</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-13">2024年4月13日公開</time>
-              </p>
-              <p>新築営業の経験を活かしてリフォーム営業で成功するための提案術、新築営業との違い、成功の秘訣を徹底解説します。</p>
+            <a class="article-card" href="/articles/renovation_sales_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム営業で成果を出す！新築経験を活かす提案術と成功の秘訣</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-13">2024年4月13日公開</time>
+                </p>
+                <p>新築営業の経験を活かしてリフォーム営業で成功するための提案術、新築営業との違い、成功の秘訣を徹底解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム営業のイメージ" loading="lazy" src="images_renovation_sales_1/導入_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_industry_fair_1.html">
-              <h2>リフォーム産業フェア活用術！経営課題解決と成長戦略のヒント</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-12">2024年4月12日公開</time>
-              </p>
-              <p>リフォーム産業フェアを戦略的に活用し、経営課題解決と未来の成長戦略に繋げるための具体的な方法を解説します。最新トレンド、DX化、新規事業のヒントが満載です。</p>
+            <a class="article-card" href="/articles/renovation_industry_fair_1.html">
+              <div class="article-card-content">
+                <h2>リフォーム産業フェア活用術！経営課題解決と成長戦略のヒント</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-12">2024年4月12日公開</time>
+                </p>
+                <p>リフォーム産業フェアを戦略的に活用し、経営課題解決と未来の成長戦略に繋げるための具体的な方法を解説します。最新トレンド、DX化、新規事業のヒントが満載です。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォーム産業フェア活用術！経営課題解決と成長戦略のヒント" loading="lazy" src="images_renovation_industry_fair_1/タイトル（H1）_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_industrial_news_1.html">
-              <h2>「本当の自分」と出会う旅へ：心を整え、軽やかに生きるためのヒント</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-11">2024年4月11日公開</time>
-              </p>
-              <p>日々の疲れを感じているあなたへ。自分を知り、心の余白を作り、人間関係を整えることで、軽やかに生きるための具体的なヒントをご紹介します。</p>
+            <a class="article-card" href="/articles/renovation_industrial_news_1.html">
+              <div class="article-card-content">
+                <h2>「本当の自分」と出会う旅へ：心を整え、軽やかに生きるためのヒント</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-11">2024年4月11日公開</time>
+                </p>
+                <p>日々の疲れを感じているあなたへ。自分を知り、心の余白を作り、人間関係を整えることで、軽やかに生きるための具体的なヒントをご紹介します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="本当の自分と出会う旅を象徴するイメージ" loading="lazy" src="images_renovation_industrial_news_1/タイトル（H1）_2.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/renovation_sliding_door_1.html">
-              <h2>タイトル未定の人生（nan）を、自分色に彩るために</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-10">2024年4月10日公開</time>
-              </p>
-              <p>繰り返される日常の中で「このままでいいのかな？」と感じていませんか？この記事は、タイトル未定の人生を自分らしく彩るための自己理解、心地よい習慣、人間関係のヒントを提案します。</p>
+            <a class="article-card" href="/articles/renovation_sliding_door_1.html">
+              <div class="article-card-content">
+                <h2>タイトル未定の人生（nan）を、自分色に彩るために</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-10">2024年4月10日公開</time>
+                </p>
+                <p>繰り返される日常の中で「このままでいいのかな？」と感じていませんか？この記事は、タイトル未定の人生を自分らしく彩るための自己理解、心地よい習慣、人間関係のヒントを提案します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="タイトル未定の人生を彩るイメージ" loading="lazy" src="images_renovation_sliding_door_1/タイトル（H1）_3.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_renovation_1.html">
-              <h2>マンションリフォームとリノベーション！理想を叶える選択ガイド</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-09">2024年4月9日公開</time>
-              </p>
-              <p>マンションリフォームとリノベーションの違いを徹底解説。それぞれのメリット・デメリット、費用相場、失敗しない計画の立て方まで、理想の住まいを実現するための完全ガイド。</p>
+            <a class="article-card" href="/articles/remodel_renovation_1.html">
+              <div class="article-card-content">
+                <h2>マンションリフォームとリノベーション！理想を叶える選択ガイド</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-09">2024年4月9日公開</time>
+                </p>
+                <p>マンションリフォームとリノベーションの違いを徹底解説。それぞれのメリット・デメリット、費用相場、失敗しない計画の立て方まで、理想の住まいを実現するための完全ガイド。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="マンションリフォームとリノベーション！理想を叶える選択ガイド" loading="lazy" src="images_remodel_renovation_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_renovation_difference_1.html">
-              <h2>中古マンション購入者必見！リフォームとリノベーションの違いと賢い選択術</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-08">2024年4月8日公開</time>
-              </p>
-              <p>中古マンション購入者向けに、リフォームとリノベーションの違い、費用、メリット・デメリットを徹底解説。後悔しないための賢い選択術を学びましょう。</p>
+            <a class="article-card" href="/articles/remodel_renovation_difference_1.html">
+              <div class="article-card-content">
+                <h2>中古マンション購入者必見！リフォームとリノベーションの違いと賢い選択術</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-08">2024年4月8日公開</time>
+                </p>
+                <p>中古マンション購入者向けに、リフォームとリノベーションの違い、費用、メリット・デメリットを徹底解説。後悔しないための賢い選択術を学びましょう。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームかリノベーションか検討する夫婦" loading="lazy" src="images_remodel_renovation_difference_1/導入_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_vs_1.html">
-              <h2>リフォームとは？リノベーションとの違いや費用相場を徹底解説</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-07">2024年4月7日公開</time>
-              </p>
-              <p>リフォームの基本的な定義から、リノベーションとの明確な違い、気になる場所別の費用相場、そして後悔しないための業者の選び方まで、知っておきたい情報を網羅的に解説します。</p>
+            <a class="article-card" href="/articles/remodel_vs_1.html">
+              <div class="article-card-content">
+                <h2>リフォームとは？リノベーションとの違いや費用相場を徹底解説</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-07">2024年4月7日公開</time>
+                </p>
+                <p>リフォームの基本的な定義から、リノベーションとの明確な違い、気になる場所別の費用相場、そして後悔しないための業者の選び方まで、知っておきたい情報を網羅的に解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="リフォームとは？リノベーションとの違いや費用相場を徹底解説" loading="lazy" src="images_remodel_vs_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
           <li>
-            <a href="/articles/remodel_wallpaper_1.html">
-              <h2>良いコーヒーを自宅で楽しむ！失敗しない豆選びから美味しい淹れ方まで</h2>
-              <p class="article-meta">
-                <time datetime="2024-04-06">2024年4月6日公開</time>
-              </p>
-              <p>自宅で美味しいコーヒーを淹れるための完全ガイド。失敗しないコーヒー豆の選び方から、ハンドドリップのコツ、おすすめの器具まで詳しく解説します。</p>
+            <a class="article-card" href="/articles/remodel_wallpaper_1.html">
+              <div class="article-card-content">
+                <h2>良いコーヒーを自宅で楽しむ！失敗しない豆選びから美味しい淹れ方まで</h2>
+                <p class="article-meta">
+                  <time datetime="2024-04-06">2024年4月6日公開</time>
+                </p>
+                <p>自宅で美味しいコーヒーを淹れるための完全ガイド。失敗しないコーヒー豆の選び方から、ハンドドリップのコツ、おすすめの器具まで詳しく解説します。</p>
+              </div>
+              <figure class="article-card-thumb">
+                <img alt="良いコーヒーを自宅で楽しむ！失敗しない豆選びから美味しい淹れ方まで" loading="lazy" src="images_remodel_wallpaper_1/タイトル（H1）_1.png" />
+              </figure>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Summary
- wrap each article listing in a two-column grid so the thumbnail sits in the rightmost third on wide screens and stacks on mobile
- add `<figure>` thumbnails with lazy-loaded images for every article card on the index page

## Testing
- npm run build *(fails: cannot find type definition files for 'node' and 'vite/client' because dependencies are unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e79c433a188330a9ffb79f57dfc0c9