### PR TITLE
Fix GitHub Pages base path configuration

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,4 +2,5 @@ import react from "@vitejs/plugin-react";
 
 export default {
   plugins: [react()],
+  base: "./",
 };


### PR DESCRIPTION
## Summary
- configure Vite to emit relative asset paths so the site loads correctly when hosted from a subdirectory such as GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f32ef5453483309c9826c144cb7769